### PR TITLE
Fix/Respect extra spaces in strings

### DIFF
--- a/src/components/wc-typeit/wc-typeit.css
+++ b/src/components/wc-typeit/wc-typeit.css
@@ -1,5 +1,6 @@
 :host {
   --cursor-color: #000000;
+  white-space: pre-wrap;
 }
 
 :host:after {


### PR DESCRIPTION
It solves https://github.com/sample-stenciljs-projects/wc-typeit/issues/40 where we now do not ignore trailing spaces while rendering text.